### PR TITLE
[BR-ServiceRequestStatus]

### DIFF
--- a/controller/service_request_controller.go
+++ b/controller/service_request_controller.go
@@ -62,7 +62,7 @@ func (RequestController) Store() gin.HandlerFunc {
 		t := time.Now()
 		request.Date = fmt.Sprintf("%d-%02d-%02d", t.Year(), t.Month(), t.Day())
 		request.HasBeenReviewed = false
-		request.Status = 1
+		request.Status = entity.PENDING_OF_ACCEPTANCE
 
 		result := db.Create(&request)
 


### PR DESCRIPTION
Se cambió el código para que al publicar una solicitud de servicio, esta se guarde con el estado 'pendiente de aceptación', ya que antes se guardaba en estado 'activo'