### PR TITLE
[BR-CORSUpdate]

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -8,7 +8,7 @@ func CORSMiddleware() gin.HandlerFunc {
 		c.Header("Access-Control-Allow-Origin", "*")
 		c.Header("Access-Control-Allow-Credentials", "true")
 		c.Header("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization, accept, origin, Cache-Control, X-Requested-With")
-		c.Header("Access-Control-Allow-Methods", "POST,HEAD,PATCH, OPTIONS, GET, PUT")
+		c.Header("Access-Control-Allow-Methods", "POST,HEAD,PATCH, OPTIONS, GET, PUT,DELETE")
 				
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(204)


### PR DESCRIPTION
Se añadió el método DELETE a los métodos permitidos en el middleware que controla el CORS